### PR TITLE
投稿画像の拡張子にwebpを追加

### DIFF
--- a/app/controllers/images_controller.rb
+++ b/app/controllers/images_controller.rb
@@ -112,7 +112,7 @@ class ImagesController < ApplicationController
   # バリデーション
   def validate_image(image)
     image.is_a?(ActionDispatch::Http::UploadedFile) &&
-      ['image/png', 'image/gif', 'image/jpeg'].include?(image.content_type) &&
+      ['image/png', 'image/jpeg', 'image/webp'].include?(image.content_type) &&
       image.size <= 20.megabytes
   end
 

--- a/app/controllers/images_controller.rb
+++ b/app/controllers/images_controller.rb
@@ -113,13 +113,7 @@ class ImagesController < ApplicationController
   def validate_image(image)
     image.is_a?(ActionDispatch::Http::UploadedFile) &&
       ['image/png', 'image/jpeg', 'image/webp'].include?(image.content_type) &&
-      image.size <= 20.megabytes &&
-      allowed_image_extension?(image.original_filename)
-  end
-
-  def allowed_image_extension?(filename)
-    allowed_extensions = ['.png', '.jpg', '.jpeg', '.webp']
-    File.extname(filename).downcase.in?(allowed_extensions)
+      image.size <= 20.megabytes
   end
 
   def validate_caption(caption)

--- a/app/controllers/images_controller.rb
+++ b/app/controllers/images_controller.rb
@@ -113,7 +113,13 @@ class ImagesController < ApplicationController
   def validate_image(image)
     image.is_a?(ActionDispatch::Http::UploadedFile) &&
       ['image/png', 'image/jpeg', 'image/webp'].include?(image.content_type) &&
-      image.size <= 20.megabytes
+      image.size <= 20.megabytes &&
+      allowed_image_extension?(image.original_filename)
+  end
+
+  def allowed_image_extension?(filename)
+    allowed_extensions = ['.png', '.jpg', '.jpeg', '.webp']
+    File.extname(filename).downcase.in?(allowed_extensions)
   end
 
   def validate_caption(caption)


### PR DESCRIPTION
投稿表示にwebpを使うため、沿うように変更します。また、webpはアニメーションに対応していないためgifは削除しました。