### PR TITLE
原寸以外の表示画像はwebp画像のURLを参照するように変更

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -46,7 +46,7 @@ class ApplicationController < ActionController::API
             key: "#{image.storage_name}.webp"
           },
           {
-            key: "#{image.storage_name}_original"
+            key: image.image_url.gsub(aws_bucket_url, '').to_s
           }
         ]
       }

--- a/app/controllers/images_controller.rb
+++ b/app/controllers/images_controller.rb
@@ -11,7 +11,7 @@ class ImagesController < ApplicationController
       {
         caption: image.caption,
         image_name: image.image_name,
-        resize_image_url: "#{aws_bucket_url}#{image.storage_name}.webp"
+        resized_image_url: "#{aws_bucket_url}#{image.storage_name}.webp"
       }
     end
     render json: data.to_json
@@ -20,11 +20,11 @@ class ImagesController < ApplicationController
   # 画像Dataを作成
   def imagedata
     image = Image.create_imagedata(params[:image_name])
-    resize_image_url = "#{aws_bucket_url}#{image.storage_name}.webp"
+    resized_image_url = "#{aws_bucket_url}#{image.storage_name}.webp"
     data = {
       caption: image.caption,
       image_url: image.image_url,
-      resize_image_url: resize_image_url
+      resized_image_url: resized_image_url
     }
     render json: data.to_json
   end

--- a/app/controllers/images_controller.rb
+++ b/app/controllers/images_controller.rb
@@ -6,17 +6,25 @@ class ImagesController < ApplicationController
   # 画像Listを作成
   def imagelist
     creator = Creator.search_creator_from_twitter_id(params[:creator_id])
-    data = Image.create_imagelist(creator.id)
+    image_data = Image.create_imagelist(creator.id)
+    data = image_data.map do |image|
+      {
+        caption: image.caption,
+        image_name: image.image_name,
+        webp_image_url: "https://#{ENV.fetch('AWS_BUCKET')}.s3.#{ENV.fetch('AWS_REGION')}.amazonaws.com/#{image.storage_name}.webp"
+      }
+    end
     render json: data.to_json
   end
 
   # 画像Dataを作成
   def imagedata
     image = Image.create_imagedata(params[:image_name])
+    webp_image_url = "https://#{ENV.fetch('AWS_BUCKET')}.s3.#{ENV.fetch('AWS_REGION')}.amazonaws.com/#{image.storage_name}.webp"
     data = {
       caption: image.caption,
       image_url: image.image_url,
-      created_at: image.created_at
+      webp_image_url: webp_image_url
     }
     render json: data.to_json
   end

--- a/app/controllers/images_controller.rb
+++ b/app/controllers/images_controller.rb
@@ -139,6 +139,7 @@ class ImagesController < ApplicationController
     upload_multi_size_image_to_aws(params[:image], storage_name)
     content_type = params[:image].content_type
     image_format = content_type.sub(%r{image/}, '')
+    image_url = "https://#{ENV.fetch('AWS_BUCKET')}.s3.#{ENV.fetch('AWS_REGION')}.amazonaws.com/#{storage_name}.#{image_format}"
     Image.update_url(image, image_url, storage_name)
   end
 end

--- a/app/controllers/images_controller.rb
+++ b/app/controllers/images_controller.rb
@@ -11,7 +11,7 @@ class ImagesController < ApplicationController
       {
         caption: image.caption,
         image_name: image.image_name,
-        webp_image_url: "#{aws_bucket_url}#{image.storage_name}.webp"
+        resize_image_url: "#{aws_bucket_url}#{image.storage_name}.webp"
       }
     end
     render json: data.to_json
@@ -20,11 +20,11 @@ class ImagesController < ApplicationController
   # 画像Dataを作成
   def imagedata
     image = Image.create_imagedata(params[:image_name])
-    webp_image_url = "#{aws_bucket_url}#{image.storage_name}.webp"
+    resize_image_url = "#{aws_bucket_url}#{image.storage_name}.webp"
     data = {
       caption: image.caption,
       image_url: image.image_url,
-      webp_image_url: webp_image_url
+      resize_image_url: resize_image_url
     }
     render json: data.to_json
   end

--- a/app/controllers/images_controller.rb
+++ b/app/controllers/images_controller.rb
@@ -121,8 +121,7 @@ class ImagesController < ApplicationController
   end
 
   # AWS S3投稿画像の作成
-  def upload_multi_size_image_to_aws(image_data, storage_name)
-    content_type = image_data.content_type
+  def upload_multi_size_image_to_aws(image_data, storage_name, content_type)
     temp_image = image_data
     input_image = MiniMagick::Image.open(temp_image.tempfile.path)
     input_image.resize '1200x1200>'
@@ -136,9 +135,9 @@ class ImagesController < ApplicationController
   # 画像をAWS S3にアップロードしURLをDBに保存
   def update_imagedata(image)
     storage_name = create_storage_name(image)
-    upload_multi_size_image_to_aws(params[:image], storage_name)
     content_type = params[:image].content_type
     image_format = content_type.sub(%r{image/}, '')
+    upload_multi_size_image_to_aws(params[:image], storage_name, content_type)
     image_url = "https://#{ENV.fetch('AWS_BUCKET')}.s3.#{ENV.fetch('AWS_REGION')}.amazonaws.com/#{storage_name}.#{image_format}"
     Image.update_url(image, image_url, storage_name)
   end

--- a/app/controllers/images_controller.rb
+++ b/app/controllers/images_controller.rb
@@ -129,7 +129,7 @@ class ImagesController < ApplicationController
     input_image.format 'webp'
     storage_name_webp = "#{storage_name}.webp"
     upload_to_aws(input_image.to_blob, storage_name_webp, 'image/webp')
-    storage_name_original = "#{storage_name}_original"
+    storage_name_original = "#{storage_name}.#{content_type.sub(%r{image/}, '')}"
     upload_to_aws(image_data, storage_name_original, content_type)
   end
 
@@ -137,7 +137,8 @@ class ImagesController < ApplicationController
   def update_imagedata(image)
     storage_name = create_storage_name(image)
     upload_multi_size_image_to_aws(params[:image], storage_name)
-    image_url = "https://#{ENV.fetch('AWS_BUCKET')}.s3.#{ENV.fetch('AWS_REGION')}.amazonaws.com/#{storage_name}.webp"
+    content_type = params[:image].content_type
+    image_format = content_type.sub(%r{image/}, '')
     Image.update_url(image, image_url, storage_name)
   end
 end

--- a/app/models/image.rb
+++ b/app/models/image.rb
@@ -6,7 +6,8 @@ class Image < ApplicationRecord
 
   # 該当クリエイターの全画像のデータを取得
   def self.create_imagelist(creator_id)
-    Image.where(creator_id: creator_id).select(:caption, :image_url, :image_name).order(created_at: :desc)
+    Image.where(creator_id: creator_id).select(:caption, :image_url, :image_name,
+                                               :storage_name).order(created_at: :desc)
   end
 
   # image_nameから画像を取得


### PR DESCRIPTION
webp画像のURLはDBに直接ほぞんしていないので、storage_nameからAWSにあるwebp画像のURLを生成しています。