### PR TITLE
画像投稿失敗時に失敗データが保存されていた問題

### DIFF
--- a/app/controllers/images_controller.rb
+++ b/app/controllers/images_controller.rb
@@ -40,13 +40,13 @@ class ImagesController < ApplicationController
       return
     end
     image = Image.create_image_from(params[:caption], @current_creator.id)
-    unless Image.image_save(image)
-      render json: { message: 'Internal Server Error' }, status: 500 # サーバーエラー
-      return
+    if Image.image_save(image)
+      create_image_name(image)
+      update_imagedata(image)
+      render json: { message: 'Created' }, status: 201
+    else
+      render json: { message: 'Internal Server Error' }, status: 500
     end
-    create_image_name(image)
-    update_imagedata(image)
-    render json: { message: 'Created' }, status: 201
   end
 
   # 画像を更新
@@ -117,17 +117,6 @@ class ImagesController < ApplicationController
     image_name
   end
 
-  # バリデーション
-  def validate_image(image)
-    image.is_a?(ActionDispatch::Http::UploadedFile) &&
-      ['image/png', 'image/jpeg', 'image/webp'].include?(image.content_type) &&
-      image.size <= 20.megabytes
-  end
-
-  def validate_caption(caption)
-    caption.is_a?(String) && caption.length <= 1000
-  end
-
   # AWS S3投稿画像の作成
   def upload_multi_size_image_to_aws(image_data, storage_name, content_type)
     temp_image = image_data
@@ -152,5 +141,16 @@ class ImagesController < ApplicationController
   # amazon S3へリクエストを送る時のバケットなどのURL
   def aws_bucket_url
     "https://#{ENV.fetch('AWS_BUCKET')}.s3.#{ENV.fetch('AWS_REGION')}.amazonaws.com/"
+  end
+
+  # バリデーション
+  def validate_image(image)
+    image.is_a?(ActionDispatch::Http::UploadedFile) &&
+      ['image/png', 'image/jpeg', 'image/webp'].include?(image.content_type) &&
+      image.size <= 20.megabytes
+  end
+
+  def validate_caption(caption)
+    caption.is_a?(String) && caption.length <= 1000
   end
 end

--- a/app/controllers/images_controller.rb
+++ b/app/controllers/images_controller.rb
@@ -35,22 +35,17 @@ class ImagesController < ApplicationController
       render json: { message: 'Unauthorized' }, status: 401
       return
     end
-
     unless validate_image(params[:image]) && validate_caption(params[:caption])
       render json: { message: 'Unprocessable Entity' }, status: 422
       return
     end
-
-    ActiveRecord::Base.transaction do # トランザクションの開始
+    ActiveRecord::Base.transaction do
       image = Image.create_image_from(params[:caption], @current_creator.id)
-
       raise ActiveRecord::Rollback unless Image.image_save(image)
 
       create_image_name(image)
       update_imagedata(image)
       render json: { message: 'Created' }, status: 201
-
-      # ロールバックを実行
     end
     render json: { message: 'Internal Server Error' }, status: 500
   end

--- a/app/controllers/images_controller.rb
+++ b/app/controllers/images_controller.rb
@@ -39,15 +39,19 @@ class ImagesController < ApplicationController
       render json: { message: 'Unprocessable Entity' }, status: 422
       return
     end
-    ActiveRecord::Base.transaction do
-      image = Image.create_image_from(params[:caption], @current_creator.id)
-      raise ActiveRecord::Rollback unless Image.image_save(image)
+    # TODO: transactionの使い方をRails有識者に聞く
+    begin
+      ActiveRecord::Base.transaction do
+        image = Image.create_image_from(params[:caption], @current_creator.id)
+        raise ActiveRecord::Rollback unless Image.image_save(image)
 
-      create_image_name(image)
-      update_imagedata(image)
-      render json: { message: 'Created' }, status: 201
+        create_image_name(image)
+        update_imagedata(image)
+        render json: { message: 'Created' }, status: 201
+      end
+    rescue ActiveRecord::Rollback
+      render json: { message: 'Internal Server Error' }, status: 500
     end
-    render json: { message: 'Internal Server Error' }, status: 500
   end
 
   # 画像を更新

--- a/app/controllers/images_controller.rb
+++ b/app/controllers/images_controller.rb
@@ -44,16 +44,14 @@ class ImagesController < ApplicationController
     ActiveRecord::Base.transaction do # トランザクションの開始
       image = Image.create_image_from(params[:caption], @current_creator.id)
 
-      if Image.image_save(image)
-        create_image_name(image)
-        update_imagedata(image)
-        render json: { message: 'Created' }, status: 201
-      else
-        raise ActiveRecord::Rollback # ロールバックを実行
-        render json: { message: 'Internal Server Error' }, status: 500
-      end
+      raise ActiveRecord::Rollback unless Image.image_save(image)
+
+      create_image_name(image)
+      update_imagedata(image)
+      render json: { message: 'Created' }, status: 201
+
+      # ロールバックを実行
     end
-  rescue StandardError => e
     render json: { message: 'Internal Server Error' }, status: 500
   end
 


### PR DESCRIPTION
失敗データが保存されていた理由：
- 画像を縮小・保存する前にimage_nameがモデルに保存されている
- 画像を縮小・保存する前にstorage_nameがモデルに保存されている

上記2つだったため、トランザクションを使い、エラーが起きたときロールバックするようにしました。