### PR TITLE
投稿画像の回転を修正

### DIFF
--- a/app/controllers/images_controller.rb
+++ b/app/controllers/images_controller.rb
@@ -126,6 +126,7 @@ class ImagesController < ApplicationController
   def upload_multi_size_image_to_aws(image_data, storage_name, content_type)
     temp_image = image_data
     input_image = MiniMagick::Image.open(temp_image.tempfile.path)
+    input_image.auto_orient
     input_image.resize '1200x1200>'
     input_image.format 'webp'
     upload_to_aws(input_image.to_blob, "#{storage_name}.webp", 'image/webp')


### PR DESCRIPTION
## 解決した問題
携帯電話で撮影した画像正しい向きになっていなかった(画像が回転していた)

## やったこと
投稿画像作成時にauto_orientを追加
auto_orientは、画像のEXIF情報に含まれる撮影時のカメラの向きのデータを読み取り、必要に応じて画像を適切な向きに自動調整する。

## やっていないこと
過去の回転した画像の削除など